### PR TITLE
change check first to check have

### DIFF
--- a/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/ConfigurationRegistry.java
+++ b/modules/configuration/src/main/java/org/apache/ignite/internal/configuration/ConfigurationRegistry.java
@@ -422,10 +422,14 @@ public class ConfigurationRegistry implements IgniteComponent, ConfigurationStor
 
         for (Map.Entry<Class<?>, Set<Class<?>>> e : polymorphicExtensionsByParent.entrySet()) {
             Class<?> schemaClass = e.getKey();
-
-            Field typeIdField = schemaFields(schemaClass).get(0);
-
-            if (!isPolymorphicId(typeIdField)) {
+            boolean havePolymorphicId = false;
+            for (Field typeIdField : schemaFields(schemaClass)) {
+                if (isPolymorphicId(typeIdField)) {
+                    havePolymorphicId = true;
+                    break;
+                }
+            }
+            if (!havePolymorphicId) {
                 throw new IllegalArgumentException(String.format(
                         "First field in a polymorphic configuration schema must contain @%s: %s",
                         PolymorphicId.class,


### PR DESCRIPTION
It is specified that the field in a polymorphic configuration schema must contain @interface PolymorphicId (specified in org.apache.ignite.configuration.annotation).
Also, getDeclaredFields() is used to get all fields of a class and check the first one.
In ConfigurationRegistry.java, line 427
```Java
Field typeIdField = schemaFields(schemaClass).get(0);
if (!isPolymorphicId(typeIdField)) {
    throw new IllegalArgumentException(String.format(
            "First field in a polymorphic configuration schema must contain @%s: %s",
            PolymorphicId.class,
            schemaClass.getName()
    ));
}
```
The `schemaFields()` just uses getDeclaredFields() if you look into it.
The problem is that the order of fields of getDeclaredFields is nondeterministic.
> The elements in the returned array are not sorted and are not in any particular order.

Therefore we cannot use this method to check the first field of a class.
However, I didn't find a suitable way to get the very first field. I am also wondering about the necessity of requiring that field to be the first. Why don't we just require the existence of that field?
So my fix actually changes the intended design of the interface. I know it is not good to do this, but I feel it is reasonable. I am not very familiar with the structure of a class in java. So I am willing to change the way I fix it if there is a necessity to keep that field as the first one.

Also, the flaky test still failed after this fix, which means I did not fix this flaky test entirely yet. Because there seem to be other issues. And the error log gives so little information that I cannot locate it. But I feel my fix should solve most part of this problem.

I attached the log here.
> java.lang.AssertionError: org.apache.ignite.configuration.schemas.table.TableIndexConfigurationSchema
	at org.apache.ignite.internal.schema.configuration.SchemaConfigurationConverterTest.createRegistry(SchemaConfigurationConverterTest.java:97)